### PR TITLE
fix: bag mask InputPhone

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "i18next-browser-languagedetector": "^7.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    
     "react-hook-form": "^7.48.2",
     "react-i18next": "^13.5.0",
     "react-input-mask": "^3.0.0-alpha.2",

--- a/src/components/InputPhone/InputPhone.tsx
+++ b/src/components/InputPhone/InputPhone.tsx
@@ -40,7 +40,7 @@ const InputPhone: FC<InputPhone> = (props) => {
                         message: t('components.inputPhone.invalidPhoneNumberFormat'),
                     },
                 })}
-                mask="+7 (999) 99-99-99"
+                mask="+7 (999) 999-99-99"
             ></InputMask>
             {errorMessage && <p className={styles.input__error}>{errorMessage}</p>}
         </div>


### PR DESCRIPTION
В маске номера телефона InputPhone не хватает символа для ввода стандартного мобильного номера РФ. Не знаю может это так и решили или временно, но таску и ПР сделаю.
![Bag InputPhone](https://github.com/bronfood-com/front/assets/99470278/f2b028e8-14f9-4c7a-9012-78d5713e85e9)
