### PR TITLE
Fix/routing

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,6 +14,5 @@ module.exports = {
       "warn",
       { allowConstantExport: true },
     ],
-    
   },
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,5 +14,6 @@ module.exports = {
       "warn",
       { allowConstantExport: true },
     ],
+    "no-console": process.env.NODE_ENV === "production" ? "error" : "warn",
   },
 };

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,6 +14,6 @@ module.exports = {
       "warn",
       { allowConstantExport: true },
     ],
-    "no-console": process.env.NODE_ENV === "production" ? "error" : "warn",
+    
   },
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,8 @@ function App() {
     const { pathname } = useLocation();
     const { currentUser } = useCurrentUser();
     useEffect(() => {
-        const path = process.env.NODE_ENV === 'production' ? '/front/*' : '/';
+        console.log(pathname);
+        const path = process.env.NODE_ENV === 'production' ? '/front/pr-preview/pr-63/' : '/';
         if (currentUser && pathname === path) {
             navigate('/restaurants');
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
     const { pathname } = useLocation();
     const { currentUser } = useCurrentUser();
     useEffect(() => {
-        const path = process.env.NODE_ENV === 'production' ? '/front/' : '/';
+        const path = process.env.NODE_ENV === 'production' ? '/front' : '/';
         if (currentUser && pathname === path) {
             navigate('/restaurants');
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
     const { pathname } = useLocation();
     const { currentUser } = useCurrentUser();
     useEffect(() => {
-        const path = process.env.NODE_ENV === 'production' ? '/front' : '/';
+        const path = process.env.NODE_ENV === 'production' ? '/front/*' : '/';
         if (currentUser && pathname === path) {
             navigate('/restaurants');
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,9 +19,7 @@ function App() {
     const { pathname } = useLocation();
     const { currentUser } = useCurrentUser();
     useEffect(() => {
-        console.log(pathname);
-        const path = process.env.NODE_ENV === 'production' ? '/pr-preview/pr-63/' : '/';
-        if (currentUser && pathname === path) {
+        if (currentUser && pathname === '/') {
             navigate('/restaurants');
         }
     }, [currentUser, navigate, pathname]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Routes, Route, useNavigate } from 'react-router-dom';
+import { Routes, Route, useNavigate, useLocation } from 'react-router-dom';
 import Header from './components/Header/Header';
 import Profile from './pages/Profile/Profile';
 import SignIn from './pages/SignIn/SignIn';
@@ -16,13 +16,14 @@ import { useCurrentUser } from './utils/hooks/useCurrentUser/useCurretUser';
 
 function App() {
     const navigate = useNavigate();
+    const {pathname} = useLocation();
     const { currentUser } = useCurrentUser();
 
     useEffect(() => {
-        if (currentUser) {
+        if (currentUser && pathname === '/') {
             navigate('/restaurants');
         }
-    }, [currentUser, navigate]);
+    }, [currentUser, navigate, pathname]);
     return (
         <div>
             <Header />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ function App() {
     const { currentUser } = useCurrentUser();
     useEffect(() => {
         console.log(pathname);
-        const path = process.env.NODE_ENV === 'production' ? '/front/pr-preview/pr-63/' : '/';
+        const path = process.env.NODE_ENV === 'production' ? '/pr-preview/pr-63/' : '/';
         if (currentUser && pathname === path) {
             navigate('/restaurants');
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
     const { pathname } = useLocation();
     const { currentUser } = useCurrentUser();
     useEffect(() => {
-    if (currentUser && (pathname === '/' || pathname === `/pr-preview/pr-${/[0-9]*/}/`)) {
+        if (currentUser && (pathname === '/' || pathname === `/pr-preview/pr-${/[0-9]*/}/`)) {
             navigate('/restaurants');
         }
     }, [currentUser, navigate, pathname]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,8 +19,9 @@ function App() {
     const { pathname } = useLocation();
     const { currentUser } = useCurrentUser();
     useEffect(() => {
+        // Enable redirect to /restaurants in PR preview
         const regex = /\/pr-preview\/pr-\d\d\//i;
-        if (currentUser && regex.test(pathname)) {
+        if (currentUser && (regex.test(pathname) || pathname === '/')) {
             navigate('/restaurants');
         }
     }, [currentUser, navigate, pathname]);
@@ -37,7 +38,7 @@ function App() {
                 <Route path="/restaurants" element={<ProtectedRoute component={<Restaurants />} />}>
                     <Route path=":restaurantId" element={<ProtectedRoute component={<Restaurant />} />} />
                 </Route>
-                <Route path={process.env.NODE_ENV === 'production' ? '/404' : '/df'} element={<PageNotFound />} />
+                <Route path={process.env.NODE_ENV === 'production' ? '/404' : '*'} element={<PageNotFound />} />
             </Routes>
         </div>
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
     const { pathname } = useLocation();
     const { currentUser } = useCurrentUser();
     useEffect(() => {
-        if (currentUser && pathname === '/') {
+    if (currentUser && (pathname === '/' || pathname === `/pr-preview/pr-${/[0-9]*/}/`)) {
             navigate('/restaurants');
         }
     }, [currentUser, navigate, pathname]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,8 @@ function App() {
     const { pathname } = useLocation();
     const { currentUser } = useCurrentUser();
     useEffect(() => {
-        if (currentUser && pathname === '/') {
+        const path = process.env.NODE_ENV === 'production' ? '/front/' : '/'
+        if (currentUser && pathname === path) {
             navigate('/restaurants');
         }
     }, [currentUser, navigate, pathname]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
     const { pathname } = useLocation();
     const { currentUser } = useCurrentUser();
     useEffect(() => {
-        const path = process.env.NODE_ENV === 'production' ? '/front/' : '/'
+        const path = process.env.NODE_ENV === 'production' ? '/front/' : '/';
         if (currentUser && pathname === path) {
             navigate('/restaurants');
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,8 @@ function App() {
     const { pathname } = useLocation();
     const { currentUser } = useCurrentUser();
     useEffect(() => {
-        if (currentUser && (pathname === '/' || pathname === `/pr-preview/pr-${/[0-9]*/}/`)) {
+        const regex = /\/pr-preview\/pr-\d\d\//i;
+        if (currentUser && regex.test(pathname)) {
             navigate('/restaurants');
         }
     }, [currentUser, navigate, pathname]);
@@ -36,7 +37,7 @@ function App() {
                 <Route path="/restaurants" element={<ProtectedRoute component={<Restaurants />} />}>
                     <Route path=":restaurantId" element={<ProtectedRoute component={<Restaurant />} />} />
                 </Route>
-                <Route path={process.env.NODE_ENV === 'production' ? '/404' : '*'} element={<PageNotFound />} />
+                <Route path={process.env.NODE_ENV === 'production' ? '/404' : '/df'} element={<PageNotFound />} />
             </Routes>
         </div>
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import { useCurrentUser } from './utils/hooks/useCurrentUser/useCurretUser';
 
 function App() {
     const navigate = useNavigate();
-    const {pathname} = useLocation();
+    const { pathname } = useLocation();
     const { currentUser } = useCurrentUser();
 
     useEffect(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,6 @@ function App() {
     const navigate = useNavigate();
     const { pathname } = useLocation();
     const { currentUser } = useCurrentUser();
-
     useEffect(() => {
         if (currentUser && pathname === '/') {
             navigate('/restaurants');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,11 +22,7 @@ function App() {
         if (currentUser) {
             navigate('/restaurants');
         }
-        // Navigate included in dependency array makes Restaurant component open for just 0.1 sec. when a restaurant card is clicked
-        // and then close. Change of route apparently re-runs effect and redirects back to /restaurants.
-        // https://github.com/remix-run/react-router/issues/7634
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [currentUser]);
+    }, [currentUser, navigate]);
     return (
         <div>
             <Header />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import './i18n.tsx';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { CurrentUserProvider } from './contexts/CurrentUserContext.tsx';
 
-const router = createBrowserRouter([{ path: '*', element: <App />, basename: `${process.env.NODE_ENV === 'production' ? '/front/' : ''}` }]);
+const router = createBrowserRouter([{ path: '*', element: <App /> }], { basename: `${process.env.NODE_ENV === 'production' ? '/front/' : ''}` });
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
         <CurrentUserProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,15 +3,14 @@ import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.scss';
 import './i18n.tsx';
-import { BrowserRouter } from 'react-router-dom';
+import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { CurrentUserProvider } from './contexts/CurrentUserContext.tsx';
 
+const router = createBrowserRouter([{ path: "*", element: <App />, basename: `${process.env.NODE_ENV === 'production' ? '/front/' : ''}`}]);
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
-        <BrowserRouter basename={process.env.NODE_ENV === 'production' ? '/front/' : ''}>
-            <CurrentUserProvider>
-                <App />
-            </CurrentUserProvider>
-        </BrowserRouter>
+        <CurrentUserProvider>
+            <RouterProvider router={router} />
+        </CurrentUserProvider>
     </React.StrictMode>,
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import './i18n.tsx';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { CurrentUserProvider } from './contexts/CurrentUserContext.tsx';
 
-const router = createBrowserRouter([{ path: "*", element: <App />, basename: `${process.env.NODE_ENV === 'production' ? '/front/' : ''}`}]);
+const router = createBrowserRouter([{ path: '*', element: <App />, basename: `${process.env.NODE_ENV === 'production' ? '/front/' : ''}` }]);
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
         <CurrentUserProvider>

--- a/src/pages/SignIn/SignIn.tsx
+++ b/src/pages/SignIn/SignIn.tsx
@@ -28,9 +28,7 @@ const SignIn = () => {
         if (currentUser) {
             navigate('/restaurants');
         }
-        // Doesnt pass ci build with navigate deps
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [currentUser]);
+    }, [currentUser, navigate]);
 
     const onSubmit: SubmitHandler<FieldValues> = async (data) => {
         const { password, phoneNumber } = data;


### PR DESCRIPTION
Один из сотрудников Remix предложил такой [вариант решения](https://github.com/remix-run/react-router/issues/7634#issuecomment-1513091516) проблемы с useNavigate.
Я его имплементировал и попап ресторана перестал автоматически закрываться. 
Добавил navigate в массив зависимостей эффектов, где у нас были оставлены комменты. Комменты удалил.
Также пришлось добавить проверку на pathname === '/' (dev) или '/pr-preview/pr-[PR]/' (PR preview)  в App.tsx, чтобы происходил редирект на /restaurants, когда другие экраны редиректят на '/'.
