### PR TITLE
Fix/showing 404

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "homepage": "https://bronfood-com.github.io/front",
   "scripts": {
     "dev": "vite",
     "predeploy": "npm run build",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,9 +22,7 @@ function App() {
     const { pathname } = useLocation();
     const { currentUser } = useCurrentUser();
     useEffect(() => {
-        // Enable redirect to /restaurants in PR preview
-        const regex = /\/pr-preview\/pr-\d\d\//i;
-        if (currentUser && (regex.test(pathname) || pathname === '/')) {
+        if (currentUser && pathname === '/') {
             navigate('/restaurants');
         }
     }, [currentUser, navigate, pathname]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ function App() {
                     </Route>
                 </Route>
                 <Route path="/basket" element={<ProtectedRoute component={<Basket />} />} />
-                <Route path={process.env.NODE_ENV === 'production' ? '/404' : '*'} element={<PageNotFound />} />
+                <Route path="*" element={<PageNotFound />} />
             </Routes>
         </div>
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ function App() {
     const [city, setCity] = useState('');
     const navigate = useNavigate();
     const { pathname } = useLocation();
+    console.log(pathname);
     const { currentUser } = useCurrentUser();
     useEffect(() => {
         // Enable redirect to /restaurants in PR preview

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,6 @@ function App() {
     const [city, setCity] = useState('');
     const navigate = useNavigate();
     const { pathname } = useLocation();
-    console.log(pathname);
     const { currentUser } = useCurrentUser();
     useEffect(() => {
         // Enable redirect to /restaurants in PR preview

--- a/src/components/Popups/Popup/Popup.module.scss
+++ b/src/components/Popups/Popup/Popup.module.scss
@@ -26,6 +26,7 @@
         right: 5px;
         background-color: transparent;
         margin: 0 auto;
+        cursor: pointer;
 
         &:before {
             content: '';

--- a/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -11,7 +11,7 @@ export type ProtectedRouteProps = {
 
 const ProtectedRoute: FC<ProtectedRouteProps> = ({ component }) => {
     const { isLogin } = useCurrentUser();
-
+    
     return isLogin ? component : <Navigate to="/" />;
 };
 

--- a/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -11,7 +11,7 @@ export type ProtectedRouteProps = {
 
 const ProtectedRoute: FC<ProtectedRouteProps> = ({ component }) => {
     const { isLogin } = useCurrentUser();
-    
+
     return isLogin ? component : <Navigate to="/" />;
 };
 

--- a/src/contexts/CurrentUserContext.tsx
+++ b/src/contexts/CurrentUserContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, FC, useState, PropsWithChildren, useCallback, useEffect } from 'react';
+import { createContext, FC, useState, PropsWithChildren, useCallback } from 'react';
 import { FieldValues } from 'react-hook-form';
 import { authService, User, UserExtra } from '../utils/api/authService';
 import { useTranslation } from 'react-i18next';
@@ -74,7 +74,7 @@ export const CurrentUserContext = createContext<CurrentUserContent>({
 });
 
 export const CurrentUserProvider: FC<PropsWithChildren> = ({ children }) => {
-    const [currentUser, setCurrentUser] = useState<User | null>(null);
+    const [currentUser, setCurrentUser] = useState<User | null>(JSON.parse(localStorage.getItem('user')));
     const { t } = useTranslation();
     const [signInErrorMessage, setSignInErrorMessage] = useState<string | null>(null);
     const [signUpErrorMessage, setSignUpErrorMessage] = useState<string | null>(null);
@@ -84,12 +84,6 @@ export const CurrentUserProvider: FC<PropsWithChildren> = ({ children }) => {
 
     const [serverSMSCode, setServerSMSCode] = useState<string>('');
     const [confirmErrorMessage, setConfirmErrorMessage] = useState<string | null>(null);
-    useEffect(() => {
-        const user = localStorage.getItem('user');
-        if (user) {
-            setCurrentUser(JSON.parse(user));
-        }
-    }, []);
 
     const isLogin = !!currentUser;
 

--- a/src/contexts/CurrentUserContext.tsx
+++ b/src/contexts/CurrentUserContext.tsx
@@ -74,7 +74,10 @@ export const CurrentUserContext = createContext<CurrentUserContent>({
 });
 
 export const CurrentUserProvider: FC<PropsWithChildren> = ({ children }) => {
-    const [currentUser, setCurrentUser] = useState<User | null>(JSON.parse(localStorage.getItem('user')));
+    const user = localStorage.getItem('user');
+    const [currentUser, setCurrentUser] = useState<User | null>(
+        user && JSON.parse(user)
+    );
     const { t } = useTranslation();
     const [signInErrorMessage, setSignInErrorMessage] = useState<string | null>(null);
     const [signUpErrorMessage, setSignUpErrorMessage] = useState<string | null>(null);

--- a/src/contexts/CurrentUserContext.tsx
+++ b/src/contexts/CurrentUserContext.tsx
@@ -75,9 +75,7 @@ export const CurrentUserContext = createContext<CurrentUserContent>({
 
 export const CurrentUserProvider: FC<PropsWithChildren> = ({ children }) => {
     const user = localStorage.getItem('user');
-    const [currentUser, setCurrentUser] = useState<User | null>(
-        user && JSON.parse(user)
-    );
+    const [currentUser, setCurrentUser] = useState<User | null>(user && JSON.parse(user));
     const { t } = useTranslation();
     const [signInErrorMessage, setSignInErrorMessage] = useState<string | null>(null);
     const [signUpErrorMessage, setSignUpErrorMessage] = useState<string | null>(null);

--- a/src/contexts/RestaurantsContext.tsx
+++ b/src/contexts/RestaurantsContext.tsx
@@ -102,7 +102,7 @@ export const RestaurantsContext = createContext<RestaurantsContext>({
 
 export const RestaurantsProvider: FC<PropsWithChildren> = ({ children }) => {
     const [restaurantsOnMap, setRestaurantsOnMap] = useState<Restaurant[]>([]);
-    const [isLoading, setIsLoading] = useState(false);
+    const [isLoading, setIsLoading] = useState(true);
     const [selectedOptions, setSelectedOptions] = useState<Option[]>([]);
     const [selectedVenueTypes, setSelectedVenueTypes] = useState<VenueType[]>([]);
     const optionNames: string[] = selectedOptions.map((option) => option.name.toLowerCase());
@@ -127,7 +127,6 @@ export const RestaurantsProvider: FC<PropsWithChildren> = ({ children }) => {
     const restaurantsFiltered: Restaurant[] = selectedOptions.length === 0 && selectedVenueTypes.length === 0 ? restaurantsOnMap : restaurantsOnMap.filter((restaurant) => restaurant.meals.some((meal) => optionNames.includes(meal.name.toLowerCase())) || optionNames.includes(restaurant.name.toLowerCase()) || typeNames.includes(restaurant.type.toLowerCase()));
     useEffect(() => {
         const fetchRestaurants = async () => {
-            setIsLoading(true);
             const res = await restaurantsService.getRestaurants();
             if (res.status === 'error') {
                 setRestaurantsOnMap([]);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.scss';
 import './i18n.tsx';
-import { RouterProvider, createBrowserRouter, createHashRouter } from 'react-router-dom';
+import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { CurrentUserProvider } from './contexts/CurrentUserContext.tsx';
 import { RestaurantsProvider } from './contexts/RestaurantsContext.tsx';
 import { BasketProvider } from './contexts/BasketContext.tsx';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,13 +3,14 @@ import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.scss';
 import './i18n.tsx';
-import { RouterProvider, createBrowserRouter } from 'react-router-dom';
+import { RouterProvider, createBrowserRouter, createHashRouter } from 'react-router-dom';
 import { CurrentUserProvider } from './contexts/CurrentUserContext.tsx';
 import { RestaurantsProvider } from './contexts/RestaurantsContext.tsx';
 import { BasketProvider } from './contexts/BasketContext.tsx';
 
-const browserRouter = createBrowserRouter([{ path: '*', element: <App /> }], { basename: '/' });
-const hashRouter = createBrowserRouter([{ path: '*', element: <App /> }], { basename: '/front' });
+const browserRouter = createBrowserRouter([{ path: '*', element: <App /> }]);
+const hashRouter = createHashRouter([{ path: '*', element: <App /> }]);
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
         <CurrentUserProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,7 @@ import { RestaurantsProvider } from './contexts/RestaurantsContext.tsx';
 import { BasketProvider } from './contexts/BasketContext.tsx';
 
 const browserRouter = createBrowserRouter([{ path: '*', element: <App /> }], { basename: '/' });
-const hashRouter = createHashRouter([{ path: '*', element: <App /> }], { basename: '/front' });
+const hashRouter = createBrowserRouter([{ path: '*', element: <App /> }], { basename: '/front' });
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
         <CurrentUserProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,20 +3,19 @@ import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.scss';
 import './i18n.tsx';
-import { RouterProvider, createBrowserRouter, createHashRouter } from 'react-router-dom';
+import { RouterProvider, createHashRouter } from 'react-router-dom';
 import { CurrentUserProvider } from './contexts/CurrentUserContext.tsx';
 import { RestaurantsProvider } from './contexts/RestaurantsContext.tsx';
 import { BasketProvider } from './contexts/BasketContext.tsx';
 
-const browserRouter = createBrowserRouter([{ path: '*', element: <App /> }]);
-const hashRouter = createHashRouter([{ path: '*', element: <App /> }]);
+const router = createHashRouter([{ path: '*', element: <App /> }]);
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
         <CurrentUserProvider>
             <RestaurantsProvider>
                 <BasketProvider>
-                    <RouterProvider router={process.env.NODE_ENV === 'production' ? hashRouter : browserRouter} />
+                    <RouterProvider router={router} />
                 </BasketProvider>
             </RestaurantsProvider>
         </CurrentUserProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,7 +9,7 @@ import { RestaurantsProvider } from './contexts/RestaurantsContext.tsx';
 import { BasketProvider } from './contexts/BasketContext.tsx';
 
 const browserRouter = createBrowserRouter([{ path: '*', element: <App /> }], { basename: '/' });
-const hashRouter = createHashRouter([{ path: '*', element: <App /> }], { basename: '/front/' });
+const hashRouter = createHashRouter([{ path: '*', element: <App /> }], { basename: '/front' });
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
         <CurrentUserProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,8 +8,8 @@ import { CurrentUserProvider } from './contexts/CurrentUserContext.tsx';
 import { RestaurantsProvider } from './contexts/RestaurantsContext.tsx';
 import { BasketProvider } from './contexts/BasketContext.tsx';
 
-const browserRouter = createBrowserRouter([{ path: '*', element: <App /> }], { basename: `${process.env.NODE_ENV === 'production' ? '/front/' : ''}` });
-const hashRouter = createHashRouter([{ path: '*', element: <App /> }], { basename: `${process.env.NODE_ENV === 'production' ? '/front/' : ''}` });
+const browserRouter = createBrowserRouter([{ path: '*', element: <App /> }], { basename: '/' });
+const hashRouter = createHashRouter([{ path: '*', element: <App /> }], { basename: '/front/' });
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
         <CurrentUserProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,13 +9,13 @@ import { RestaurantsProvider } from './contexts/RestaurantsContext.tsx';
 import { BasketProvider } from './contexts/BasketContext.tsx';
 
 const browserRouter = createBrowserRouter([{ path: '*', element: <App /> }], { basename: '/' });
-const hashRouter = createHashRouter([{ path: '*', element: <App /> }], { basename: '/front' });
+const hashRouter = createHashRouter([{ path: '*', element: <App /> }], { basename: '' });
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
         <CurrentUserProvider>
             <RestaurantsProvider>
                 <BasketProvider>
-                    <RouterProvider router={process.env.NODE_ENV === 'production' ? hashRouter : browserRouter} />
+                    <RouterProvider router={process.env.NODE_ENV === 'production' ? hashRouter : hashRouter} />
                 </BasketProvider>
             </RestaurantsProvider>
         </CurrentUserProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,18 +3,19 @@ import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.scss';
 import './i18n.tsx';
-import { RouterProvider, createBrowserRouter } from 'react-router-dom';
+import { RouterProvider, createBrowserRouter, createHashRouter } from 'react-router-dom';
 import { CurrentUserProvider } from './contexts/CurrentUserContext.tsx';
 import { RestaurantsProvider } from './contexts/RestaurantsContext.tsx';
 import { BasketProvider } from './contexts/BasketContext.tsx';
 
-const router = createBrowserRouter([{ path: '*', element: <App /> }], { basename: `${process.env.NODE_ENV === 'production' ? '/front/' : ''}` });
+const browserRouter = createBrowserRouter([{ path: '*', element: <App /> }], { basename: `${process.env.NODE_ENV === 'production' ? '/front/' : ''}` });
+const hashRouter = createHashRouter([{ path: '*', element: <App /> }], { basename: `${process.env.NODE_ENV === 'production' ? '/front/' : ''}` });
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
         <CurrentUserProvider>
             <RestaurantsProvider>
                 <BasketProvider>
-                    <RouterProvider router={router} />
+                    <RouterProvider router={process.env.NODE_ENV === 'production' ? hashRouter : browserRouter} />
                 </BasketProvider>
             </RestaurantsProvider>
         </CurrentUserProvider>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,13 +9,13 @@ import { RestaurantsProvider } from './contexts/RestaurantsContext.tsx';
 import { BasketProvider } from './contexts/BasketContext.tsx';
 
 const browserRouter = createBrowserRouter([{ path: '*', element: <App /> }], { basename: '/' });
-const hashRouter = createHashRouter([{ path: '*', element: <App /> }], { basename: '' });
+const hashRouter = createHashRouter([{ path: '*', element: <App /> }], { basename: '/front' });
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
         <CurrentUserProvider>
             <RestaurantsProvider>
                 <BasketProvider>
-                    <RouterProvider router={process.env.NODE_ENV === 'production' ? hashRouter : hashRouter} />
+                    <RouterProvider router={process.env.NODE_ENV === 'production' ? hashRouter : browserRouter} />
                 </BasketProvider>
             </RestaurantsProvider>
         </CurrentUserProvider>

--- a/src/pages/MealPage/MealPage.tsx
+++ b/src/pages/MealPage/MealPage.tsx
@@ -85,7 +85,7 @@ function MealPage() {
                 </form>
             </FormProvider>
         );
-    } else return <PageNotFound />
+    } else return <PageNotFound />;
 }
 
 export default MealPage;

--- a/src/pages/MealPage/MealPage.tsx
+++ b/src/pages/MealPage/MealPage.tsx
@@ -11,6 +11,7 @@ import MealFeatureList from './MealFeatureList/MealFeatureList';
 import Preloader from '../../components/Preloader/Preloader';
 import { Feature, Meal, Restaurant } from '../../utils/api/restaurantsService/restaurantsService';
 import { sumBy } from 'lodash';
+import PageNotFound from '../PageNotFound/PageNotFound';
 
 function MealPage() {
     const [features, setFeatures] = useState<Feature[]>([]);
@@ -84,7 +85,7 @@ function MealPage() {
                 </form>
             </FormProvider>
         );
-    }
+    } else return <PageNotFound />
 }
 
 export default MealPage;

--- a/src/pages/Restaurants/Restaurant/Restaurant.tsx
+++ b/src/pages/Restaurants/Restaurant/Restaurant.tsx
@@ -42,7 +42,7 @@ function Restaurant() {
                 <Outlet />
             </>
         );
-    } else return <PageNotFound />
+    } else return <PageNotFound />;
 }
 
 export default Restaurant;

--- a/src/pages/Restaurants/Restaurant/Restaurant.tsx
+++ b/src/pages/Restaurants/Restaurant/Restaurant.tsx
@@ -41,9 +41,9 @@ function Restaurant() {
             </>
         );
     } else if (isLoading) {
-        return null
+        return null;
     } else if (!restaurant) {
-        return <PageNotFound />
+        return <PageNotFound />;
     }
 }
 

--- a/src/pages/Restaurants/Restaurant/Restaurant.tsx
+++ b/src/pages/Restaurants/Restaurant/Restaurant.tsx
@@ -9,12 +9,14 @@ import MealsList from './MealsList/MealsList';
 import MealsFilter from './MealsFilter/MealsFilter';
 import Preloader from '../../../components/Preloader/Preloader';
 import PageNotFound from '../../PageNotFound/PageNotFound';
+import { useBasket } from '../../../utils/hooks/useBasket/useBasket';
 
 function Restaurant() {
     const [selectedMealTypes, setSelectedMealTypes] = useState<MealType[]>([]);
     const navigate = useNavigate();
     const params = useParams();
     const { restaurantsFiltered, isLoading } = useRestaurants();
+    const {isLoading: isBasketLoading} = useBasket();
     const restaurant: RestaurantProps | undefined = restaurantsFiltered.find((restaurant) => restaurant.id === params.restaurantId);
     const close = () => {
         navigate('/restaurants');
@@ -35,7 +37,7 @@ function Restaurant() {
                     <RestaurantDescription name={restaurant.name} address={restaurant.address} workingTime={restaurant.workingTime} rating={restaurant.rating} reviews="(123+)" />
                     <MealsFilter types={types} selectedTypes={selectedMealTypes} addType={addMealType} deleteType={deleteMealType} />
                     <MealsList meals={mealsFiltered} />
-                    {isLoading && <Preloader />}
+                    {isBasketLoading && <Preloader />}
                 </RestaurantPopup>
                 <Outlet />
             </>

--- a/src/pages/Restaurants/Restaurant/Restaurant.tsx
+++ b/src/pages/Restaurants/Restaurant/Restaurant.tsx
@@ -16,7 +16,7 @@ function Restaurant() {
     const navigate = useNavigate();
     const params = useParams();
     const { restaurantsFiltered, isLoading } = useRestaurants();
-    const {isLoading: isBasketLoading} = useBasket();
+    const { isLoading: isBasketLoading } = useBasket();
     const restaurant: RestaurantProps | undefined = restaurantsFiltered.find((restaurant) => restaurant.id === params.restaurantId);
     const close = () => {
         navigate('/restaurants');

--- a/src/pages/Restaurants/Restaurant/Restaurant.tsx
+++ b/src/pages/Restaurants/Restaurant/Restaurant.tsx
@@ -8,15 +8,13 @@ import RestaurantDescription from './RestaurantDescription/RestaurantDescription
 import MealsList from './MealsList/MealsList';
 import MealsFilter from './MealsFilter/MealsFilter';
 import Preloader from '../../../components/Preloader/Preloader';
-import { useBasket } from '../../../utils/hooks/useBasket/useBasket';
 import PageNotFound from '../../PageNotFound/PageNotFound';
 
 function Restaurant() {
     const [selectedMealTypes, setSelectedMealTypes] = useState<MealType[]>([]);
     const navigate = useNavigate();
     const params = useParams();
-    const { restaurantsFiltered } = useRestaurants();
-    const { isLoading } = useBasket();
+    const { restaurantsFiltered, isLoading } = useRestaurants();
     const restaurant: RestaurantProps | undefined = restaurantsFiltered.find((restaurant) => restaurant.id === params.restaurantId);
     const close = () => {
         navigate('/restaurants');
@@ -42,7 +40,11 @@ function Restaurant() {
                 <Outlet />
             </>
         );
-    } else return <PageNotFound />;
+    } else if (isLoading) {
+        return null
+    } else if (!restaurant) {
+        return <PageNotFound />
+    }
 }
 
 export default Restaurant;

--- a/src/pages/Restaurants/Restaurant/Restaurant.tsx
+++ b/src/pages/Restaurants/Restaurant/Restaurant.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Outlet, useNavigate, useParams } from 'react-router-dom';
-import styles from './RestaurantPopup/RestaurantPopup.module.scss'
+import styles from './RestaurantPopup/RestaurantPopup.module.scss';
 import { useRestaurants } from '../../../utils/hooks/useRestaurants/useRestaurants';
 import { Meal, MealType, Restaurant as RestaurantProps } from '../../../utils/api/restaurantsService/restaurantsService';
 import RestaurantPopup from './RestaurantPopup/RestaurantPopup';
@@ -50,7 +50,7 @@ function Restaurant() {
                     <Preloader />
                 </div>
             </div>
-        )
+        );
     } else if (!restaurant) {
         return <PageNotFound />;
     }

--- a/src/pages/Restaurants/Restaurant/Restaurant.tsx
+++ b/src/pages/Restaurants/Restaurant/Restaurant.tsx
@@ -9,6 +9,7 @@ import MealsList from './MealsList/MealsList';
 import MealsFilter from './MealsFilter/MealsFilter';
 import Preloader from '../../../components/Preloader/Preloader';
 import { useBasket } from '../../../utils/hooks/useBasket/useBasket';
+import PageNotFound from '../../PageNotFound/PageNotFound';
 
 function Restaurant() {
     const [selectedMealTypes, setSelectedMealTypes] = useState<MealType[]>([]);
@@ -41,7 +42,7 @@ function Restaurant() {
                 <Outlet />
             </>
         );
-    }
+    } else return <PageNotFound />
 }
 
 export default Restaurant;

--- a/src/pages/Restaurants/Restaurant/Restaurant.tsx
+++ b/src/pages/Restaurants/Restaurant/Restaurant.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Outlet, useNavigate, useParams } from 'react-router-dom';
+import styles from './RestaurantPopup/RestaurantPopup.module.scss'
 import { useRestaurants } from '../../../utils/hooks/useRestaurants/useRestaurants';
 import { Meal, MealType, Restaurant as RestaurantProps } from '../../../utils/api/restaurantsService/restaurantsService';
 import RestaurantPopup from './RestaurantPopup/RestaurantPopup';
@@ -43,7 +44,13 @@ function Restaurant() {
             </>
         );
     } else if (isLoading) {
-        return null;
+        return (
+            <div className={styles.restaurant_popup_overlay}>
+                <div className={styles.restaurant_popup}>
+                    <Preloader />
+                </div>
+            </div>
+        )
     } else if (!restaurant) {
         return <PageNotFound />;
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,5 @@ import svgr from 'vite-plugin-svgr';
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [react(), svgr()],
-    base: process.env.NODE_ENV === 'production' ? '/front' : '',
+    base: process.env.NODE_ENV === 'production' ? '/front/#/' : '',
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,5 @@ import svgr from 'vite-plugin-svgr';
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [react(), svgr()],
-    base: process.env.NODE_ENV === 'production' ? '/front/' : '',
+    base: process.env.NODE_ENV === 'production' ? '/front' : '',
 });


### PR DESCRIPTION
Теперь, когда в URL вбит невалидный роут типа restaurants/222/meal/333, где 
222 - несуществующий id ресторана, 
333 - несуществующий id блюда,
показывается страница 404. Также, если ошибка в словах в роуте, то тоже показывается 404.

Заодно починил баг, когда если пользователь залогинен, то попытка вбить вручную в адресной строке браузера валидный "защищенный" роут приводила к редиректу на /restaurants. Проблема, оказывается, была в том, что в файле CurrentUserContext.tsx значение стейт переменной currentUser по умолчанию был null и соответственно isLogin на долю секунды становился undefined, что приводило к тому, что в файле ProtectedRoute.tsx редиректило на '/', что в свою очередь заставляло эффект в App.tsx редиректить на '/restaurants'.

Затем выяснилось, что в превью на гитхабе не работает ручное изменение URL. Поэтому пришлось для продакшена использовать createHashRouter https://reactrouter.com/en/main/routers/create-hash-router
