### PR TITLE
Feature/apply auth service real

### DIFF
--- a/src/components/SMSConfirm/SMSConfirm.tsx
+++ b/src/components/SMSConfirm/SMSConfirm.tsx
@@ -35,6 +35,10 @@ interface SMSConfirm {
      * Opening popup
      */
     popupSuccessOpened?: React.ReactNode;
+    /**
+     * Function invoked when popup closed
+     */
+    onClose: () => void;
 }
 
 const SMSConfirm: FC<SMSConfirm> = (props) => {
@@ -61,6 +65,7 @@ const SMSConfirm: FC<SMSConfirm> = (props) => {
                 <Popup
                     title={t('pages.confirmation.phoneConfirmation')}
                     onClose={() => {
+                        props.onClose();
                         navigate('/');
                     }}
                 >

--- a/src/contexts/CurrentUserContext.tsx
+++ b/src/contexts/CurrentUserContext.tsx
@@ -73,7 +73,7 @@ export const CurrentUserProvider: FC<PropsWithChildren> = ({ children }) => {
         },
     });
     useEffect(() => {
-        setCurrentUser(user);
+        setCurrentUser(user && JSON.parse(user));
     }, [user]);
     return (
         <CurrentUserContext.Provider

--- a/src/contexts/CurrentUserContext.tsx
+++ b/src/contexts/CurrentUserContext.tsx
@@ -74,7 +74,7 @@ export const CurrentUserProvider: FC<PropsWithChildren> = ({ children }) => {
     });
     useEffect(() => {
         setCurrentUser(user);
-    }, [user])
+    }, [user]);
     return (
         <CurrentUserContext.Provider
             value={{

--- a/src/contexts/CurrentUserContext.tsx
+++ b/src/contexts/CurrentUserContext.tsx
@@ -70,7 +70,6 @@ export const CurrentUserProvider: FC<PropsWithChildren> = ({ children }) => {
             localStorage.removeItem('user');
             localStorage.removeItem('token');
             setCurrentUser(null);
-            u;
         },
     });
 

--- a/src/contexts/CurrentUserContext.tsx
+++ b/src/contexts/CurrentUserContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, FC, useState, PropsWithChildren } from 'react';
+import { createContext, FC, useState, PropsWithChildren, useEffect } from 'react';
 import { authService, LoginData, RegisterData, UpdateUser, User, UserExtra } from '../utils/api/authService';
 import { useMutation, UseMutationResult } from '@tanstack/react-query';
 
@@ -72,7 +72,9 @@ export const CurrentUserProvider: FC<PropsWithChildren> = ({ children }) => {
             setCurrentUser(null);
         },
     });
-
+    useEffect(() => {
+        setCurrentUser(user);
+    }, [user])
     return (
         <CurrentUserContext.Provider
             value={{

--- a/src/contexts/CurrentUserContext.tsx
+++ b/src/contexts/CurrentUserContext.tsx
@@ -70,6 +70,7 @@ export const CurrentUserProvider: FC<PropsWithChildren> = ({ children }) => {
             localStorage.removeItem('user');
             localStorage.removeItem('token');
             setCurrentUser(null);
+            u;
         },
     });
 

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -109,7 +109,7 @@ i18n
                             areYouSure: 'Вы уверены, что хотите выйти?',
                             signout: 'Выйти',
                             serverError: 'Ошибка на сервере',
-                            unauthorized: 'Вы не авторизованы',
+                            Unauthorized: 'Вы не авторизованы',
                         },
                         pageNotFound: {
                             goBack: 'Вернуться на главную',

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -109,6 +109,7 @@ i18n
                             areYouSure: 'Вы уверены, что хотите выйти?',
                             signout: 'Выйти',
                             serverError: 'Ошибка на сервере',
+                            unauthorized: 'Вы не авторизованы',
                         },
                         pageNotFound: {
                             goBack: 'Вернуться на главную',

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -103,6 +103,7 @@ i18n
                             enterSmsCode: 'Ввведите код из смс',
                             validationError: 'Неверный код',
                             serverError: 'Ошибка сервера',
+                            invalidConformationCode: 'Введен неправильный код',
                         },
                         logout: {
                             areYouSure: 'Вы уверены, что хотите выйти?',

--- a/src/pages/Logout/Logout.tsx
+++ b/src/pages/Logout/Logout.tsx
@@ -35,7 +35,10 @@ const Logout: FC = () => {
             navigate('/');
         }
     }, [currentUser, navigate]);
-    useEsc(() => {logout.reset(); navigate('/')}, [navigate]);
+    useEsc(() => {
+        logout.reset();
+        navigate('/');
+    }, [navigate]);
 
     return (
         <div className={styles.logout} onClick={handleOverlayClick}>

--- a/src/pages/Logout/Logout.tsx
+++ b/src/pages/Logout/Logout.tsx
@@ -42,7 +42,7 @@ const Logout: FC = () => {
 
     return (
         <div className={styles.logout} onClick={handleOverlayClick}>
-            <ConfirmationPopup title={t(`pages.logout.areYouSure`)} confirmButtonText={t(`pages.logout.signout`)} onCancel={() => navigate('/')} onSubmit={handleLogout}>
+            <ConfirmationPopup title={t(`pages.logout.areYouSure`)} confirmButtonText={t(`pages.logout.signout`)} onCancel={() => {logout.reset(); navigate('/')}} onSubmit={handleLogout}>
                 {logout.isPending && <Preloader />}
                 {logout.isError && <ErrorMessage message={t(`pages.logout.${logout.error.message}`)} />}
             </ConfirmationPopup>

--- a/src/pages/Logout/Logout.tsx
+++ b/src/pages/Logout/Logout.tsx
@@ -35,7 +35,7 @@ const Logout: FC = () => {
             navigate('/');
         }
     }, [currentUser, navigate]);
-    useEsc(() => navigate('/'), [navigate]);
+    useEsc(() => {logout.reset(); navigate('/')}, [navigate]);
 
     return (
         <div className={styles.logout} onClick={handleOverlayClick}>

--- a/src/pages/Logout/Logout.tsx
+++ b/src/pages/Logout/Logout.tsx
@@ -30,25 +30,25 @@ const Logout: FC = () => {
             navigate('/');
         }
     };
+    const onClose = () => {
+        logout.reset();
+        navigate('/');
+    }
     useEffect(() => {
         if (!currentUser) {
             navigate('/');
         }
     }, [currentUser, navigate]);
     useEsc(() => {
-        logout.reset();
-        navigate('/');
-    }, [navigate]);
+        onClose();
+    }, []);
 
     return (
         <div className={styles.logout} onClick={handleOverlayClick}>
             <ConfirmationPopup
                 title={t(`pages.logout.areYouSure`)}
                 confirmButtonText={t(`pages.logout.signout`)}
-                onCancel={() => {
-                    logout.reset();
-                    navigate('/');
-                }}
+                onCancel={onClose}
                 onSubmit={handleLogout}
             >
                 {logout.isPending && <Preloader />}

--- a/src/pages/Logout/Logout.tsx
+++ b/src/pages/Logout/Logout.tsx
@@ -33,7 +33,7 @@ const Logout: FC = () => {
     const onClose = () => {
         logout.reset();
         navigate('/');
-    }
+    };
     useEffect(() => {
         if (!currentUser) {
             navigate('/');
@@ -45,12 +45,7 @@ const Logout: FC = () => {
 
     return (
         <div className={styles.logout} onClick={handleOverlayClick}>
-            <ConfirmationPopup
-                title={t(`pages.logout.areYouSure`)}
-                confirmButtonText={t(`pages.logout.signout`)}
-                onCancel={onClose}
-                onSubmit={handleLogout}
-            >
+            <ConfirmationPopup title={t(`pages.logout.areYouSure`)} confirmButtonText={t(`pages.logout.signout`)} onCancel={onClose} onSubmit={handleLogout}>
                 {logout.isPending && <Preloader />}
                 {logout.isError && <ErrorMessage message={t(`pages.logout.${logout.error.message}`)} />}
             </ConfirmationPopup>

--- a/src/pages/Logout/Logout.tsx
+++ b/src/pages/Logout/Logout.tsx
@@ -42,7 +42,15 @@ const Logout: FC = () => {
 
     return (
         <div className={styles.logout} onClick={handleOverlayClick}>
-            <ConfirmationPopup title={t(`pages.logout.areYouSure`)} confirmButtonText={t(`pages.logout.signout`)} onCancel={() => {logout.reset(); navigate('/')}} onSubmit={handleLogout}>
+            <ConfirmationPopup
+                title={t(`pages.logout.areYouSure`)}
+                confirmButtonText={t(`pages.logout.signout`)}
+                onCancel={() => {
+                    logout.reset();
+                    navigate('/');
+                }}
+                onSubmit={handleLogout}
+            >
                 {logout.isPending && <Preloader />}
                 {logout.isError && <ErrorMessage message={t(`pages.logout.${logout.error.message}`)} />}
             </ConfirmationPopup>

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -63,6 +63,7 @@ const Profile = () => {
                 <Popup
                     title={t('pages.profile.title')}
                     onClose={() => {
+                        updateUser.reset();
                         navigate('/');
                     }}
                 >

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -32,7 +32,7 @@ const Profile = () => {
 
     const onSubmit: SubmitHandler<FieldValues> = async (data) => {
         await updateUser.mutateAsync({
-            phone: data.phoneNumber,
+            phone: data.phoneNumber.replace(/\D/g, ''),
             fullname: data.username,
             password: data.newPassword || null,
             confirmPassword: data.newPasswordConfirm || null,

--- a/src/pages/Profile/Profile.tsx
+++ b/src/pages/Profile/Profile.tsx
@@ -58,7 +58,7 @@ const Profile = () => {
     return (
         <>
             {isConfirmOpen ? (
-                <SMSConfirm isLoading={confirmUpdateUser.isPending} error={confirmUpdateUser.error?.message} isConfirmErrorVisible={confirmUpdateUser.isError} onSubmit={confirm} />
+                <SMSConfirm onClose={confirmUpdateUser.reset} isLoading={confirmUpdateUser.isPending} error={confirmUpdateUser.error?.message} isConfirmErrorVisible={confirmUpdateUser.isError} onSubmit={confirm} />
             ) : (
                 <Popup
                     title={t('pages.profile.title')}

--- a/src/pages/RestorePassword/RestorePassword.tsx
+++ b/src/pages/RestorePassword/RestorePassword.tsx
@@ -25,7 +25,7 @@ const RestorePassword = () => {
     };
 
     const timeoutRequest = () => {
-        return setTimeout(()=> {
+        return setTimeout(() => {
             setIsLoading(false);
             setErrorMessage(makeLowerCaseFirstLetter('serverDoesntRespond'));
             setIsError(true);

--- a/src/pages/SignIn/SignIn.tsx
+++ b/src/pages/SignIn/SignIn.tsx
@@ -41,6 +41,7 @@ const SignIn = () => {
         <Popup
             title={t('pages.signIn.signInHeading')}
             onClose={() => {
+                signIn.reset();
                 navigate('/');
             }}
         >

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -47,6 +47,7 @@ const SignUp = () => {
                 <Popup
                     title={t('pages.signUp.signUpHeading')}
                     onClose={() => {
+                        signUp.reset();
                         navigate('/');
                     }}
                 >

--- a/src/pages/SignUp/SignUp.tsx
+++ b/src/pages/SignUp/SignUp.tsx
@@ -42,7 +42,7 @@ const SignUp = () => {
     return (
         <>
             {isConfirmOpen ? (
-                <SMSConfirm isLoading={confirmSignUp.isPending} error={confirmSignUp.error?.message} isConfirmErrorVisible={confirmSignUp.isError} onSubmit={confirm} isInfoPopupOpen={isInfoPopupOpen} popupSuccessOpened={<PopupSignupSuccess isOpened={isInfoPopupOpen} />} />
+                <SMSConfirm onClose={confirmSignUp.reset} isLoading={confirmSignUp.isPending} error={confirmSignUp.error?.message} isConfirmErrorVisible={confirmSignUp.isError} onSubmit={confirm} isInfoPopupOpen={isInfoPopupOpen} popupSuccessOpened={<PopupSignupSuccess isOpened={isInfoPopupOpen} />} />
             ) : (
                 <Popup
                     title={t('pages.signUp.signUpHeading')}

--- a/src/utils/api/authService.ts
+++ b/src/utils/api/authService.ts
@@ -1,4 +1,3 @@
-// import { AuthServiceMock } from './authServiceMock';
 import { AuthServiceReal } from './authServiceReal';
 
 /**
@@ -58,5 +57,4 @@ export interface AuthService {
     logOut: () => Promise<void>;
 }
 
-// export const authService = new AuthServiceMock();
 export const authService = new AuthServiceReal();

--- a/src/utils/api/authService.ts
+++ b/src/utils/api/authService.ts
@@ -1,5 +1,5 @@
-import { AuthServiceMock } from './authServiceMock';
-// import { AuthServiceReal } from './authServiceReal';
+// import { AuthServiceMock } from './authServiceMock';
+import { AuthServiceReal } from './authServiceReal';
 
 /**
  11 digits string, no space, brackets, or +
@@ -58,5 +58,5 @@ export interface AuthService {
     logOut: () => Promise<void>;
 }
 
-export const authService = new AuthServiceMock();
-// export const authService = new AuthServiceReal();
+// export const authService = new AuthServiceMock();
+export const authService = new AuthServiceReal();

--- a/src/utils/api/authServiceReal.ts
+++ b/src/utils/api/authServiceReal.ts
@@ -66,7 +66,7 @@ export class AuthServiceReal implements AuthService {
         const token = this.getToken();
         let requestData: UpdateUser = { fullname, phone };
         if (password && confirmPassword) {
-            requestData = { ...requestData, password, password_confirm: confirmPassword };
+            requestData = { ...requestData, password, confirmPassword };
         }
         const res = await fetch(`${API_URL}/client/profile/update_request/`, {
             method: 'POST',

--- a/src/utils/api/authServiceReal.ts
+++ b/src/utils/api/authServiceReal.ts
@@ -39,7 +39,7 @@ export class AuthServiceReal implements AuthService {
         if (!res.ok) {
             throw new Error(result.error_message);
         } else {
-        return result
+            return result;
         }
     }
 
@@ -78,7 +78,7 @@ export class AuthServiceReal implements AuthService {
         if (!res.ok) {
             throw new Error(result.error_message);
         } else {
-        return result
+            return result;
         }
     }
 

--- a/src/utils/api/authServiceReal.ts
+++ b/src/utils/api/authServiceReal.ts
@@ -119,7 +119,7 @@ export class AuthServiceReal implements AuthService {
             throw new Error(res.statusText);
         } else {
             clearLocalStorage();
-            return
+            return;
         }
     }
 }

--- a/src/utils/api/authServiceReal.ts
+++ b/src/utils/api/authServiceReal.ts
@@ -63,6 +63,7 @@ export class AuthServiceReal implements AuthService {
     }
 
     async updateUser({ fullname, phone, password, confirmPassword }: UpdateUser): Promise<{ data: { temp_data_code: string } }> {
+        const token = this.getToken();
         let requestData: UpdateUser = { fullname, phone };
         if (password && confirmPassword) {
             requestData = { ...requestData, password, confirmPassword };
@@ -71,6 +72,7 @@ export class AuthServiceReal implements AuthService {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json;charset=utf-8',
+                authorization: `Token ${token}`,
             },
             body: JSON.stringify(requestData),
         });

--- a/src/utils/api/authServiceReal.ts
+++ b/src/utils/api/authServiceReal.ts
@@ -16,12 +16,15 @@ export class AuthServiceReal implements AuthService {
             },
             body: JSON.stringify({ phone, password }),
         });
-        const resultWithToken = await res.json();
-        const { auth_token } = resultWithToken.data;
-        const result = { ...resultWithToken };
-        localStorage.setItem('token', auth_token);
-        delete result.data.auth_token;
-        return result;
+        const result = await res.json();
+        if (!res.ok) {
+            throw new Error(result.error_message);
+        } else {
+            const { auth_token } = result.data;
+            localStorage.setItem('token', auth_token);
+            delete result.data.auth_token;
+            return result;
+        }
     }
 
     async register({ fullname, phone, password }: RegisterData): Promise<{ data: { temp_data_code: string } }> {
@@ -33,7 +36,11 @@ export class AuthServiceReal implements AuthService {
             body: JSON.stringify({ phone, password, fullname }),
         });
         const result = await res.json();
-        return result;
+        if (!res.ok) {
+            throw new Error(result.error_message);
+        } else {
+        return result
+        }
     }
 
     async confirmRegisterPhone({ temp_data_code, confirmation_code }: ConfirmRegisterPhoneData): Promise<{ data: User }> {
@@ -44,12 +51,15 @@ export class AuthServiceReal implements AuthService {
             },
             body: JSON.stringify({ temp_data_code, confirmation_code }),
         });
-        const resultWithToken = await res.json();
-        const { auth_token } = resultWithToken.data;
-        const result = { ...resultWithToken };
-        localStorage.setItem('token', auth_token);
-        delete result.data.auth_token;
-        return result;
+        const result = await res.json();
+        if (!res.ok) {
+            throw new Error(result.error_message);
+        } else {
+            const { auth_token } = result.data;
+            localStorage.setItem('token', auth_token);
+            delete result.data.auth_token;
+            return result;
+        }
     }
 
     async updateUser({ fullname, phone, password, confirmPassword }: UpdateUser): Promise<{ data: { temp_data_code: string } }> {
@@ -64,9 +74,12 @@ export class AuthServiceReal implements AuthService {
             },
             body: JSON.stringify(requestData),
         });
-
         const result = await res.json();
-        return result;
+        if (!res.ok) {
+            throw new Error(result.error_message);
+        } else {
+        return result
+        }
     }
 
     async confirmUpdateUser({ confirmation_code }: ConfirmUpdateUser): Promise<{ data: UserExtra }> {
@@ -78,9 +91,13 @@ export class AuthServiceReal implements AuthService {
             body: JSON.stringify({ confirmation_code }),
         });
         const result = await res.json();
-        delete result.data.auth_token;
-        delete result.data.role;
-        return result;
+        if (!res.ok) {
+            throw new Error(result.error_message);
+        } else {
+            delete result.data.auth_token;
+            delete result.data.role;
+            return result;
+        }
     }
 
     async logOut() {

--- a/src/utils/api/authServiceReal.ts
+++ b/src/utils/api/authServiceReal.ts
@@ -104,20 +104,22 @@ export class AuthServiceReal implements AuthService {
 
     async logOut() {
         const token = this.getToken();
+        const clearLocalStorage = () => {
+            localStorage.removeItem('user');
+            localStorage.removeItem('token');
+        };
         const res = await fetch(`${API_URL}/client/signout/`, {
             method: 'POST',
             headers: {
                 authorization: `Token ${token}`,
             },
         });
-        const result = await res.json();
         if (!res.ok) {
-            if (res.status === 401) {
-                throw new Error('unauthorized');
-            }
-            throw new Error(result.error_message);
+            clearLocalStorage();
+            throw new Error(res.statusText);
         } else {
-            return result;
+            clearLocalStorage();
+            return
         }
     }
 }

--- a/src/utils/api/authServiceReal.ts
+++ b/src/utils/api/authServiceReal.ts
@@ -66,7 +66,7 @@ export class AuthServiceReal implements AuthService {
         const token = this.getToken();
         let requestData: UpdateUser = { fullname, phone };
         if (password && confirmPassword) {
-            requestData = { ...requestData, password, confirmPassword };
+            requestData = { ...requestData, password, password_confirm: confirmPassword };
         }
         const res = await fetch(`${API_URL}/client/profile/update_request/`, {
             method: 'POST',

--- a/src/utils/api/authServiceReal.ts
+++ b/src/utils/api/authServiceReal.ts
@@ -104,12 +104,20 @@ export class AuthServiceReal implements AuthService {
 
     async logOut() {
         const token = this.getToken();
-        await fetch(`${API_URL}/client/signout/`, {
+        const res = await fetch(`${API_URL}/client/signout/`, {
             method: 'POST',
             headers: {
                 authorization: `Token ${token}`,
             },
         });
-        localStorage.removeItem('token');
+        const result = await res.json();
+        if (!res.ok) {
+            if (res.status === 401) {
+                throw new Error('unauthorized');
+            }
+            throw new Error(result.error_message);
+        } else {
+            return result;
+        }
     }
 }

--- a/src/utils/consts.tsx
+++ b/src/utils/consts.tsx
@@ -6,4 +6,4 @@ export const regexClientName: RegExp = /^([a-zA-Z\\-]+(?:\s[a-zA-Z\\-]+)|[a-яА
 export const regexPassword: RegExp = /^[A-Za-z\d!@#$%^&*()-_+=<>?]{4,256}$/;
 export const regexPhoneNumberKazakhstan: RegExp = /^\+7 \(\d{3}\) \d{3}-\d{2}-\d{2}$/;
 //export const API_URL = 'http://127.0.0.1:8000';
-export const API_URL = 'http://bronfood.sytes.net';
+export const API_URL = 'https://bronfood.sytes.net';

--- a/src/utils/consts.tsx
+++ b/src/utils/consts.tsx
@@ -6,4 +6,4 @@ export const regexClientName: RegExp = /^([a-zA-Z\\-]+(?:\s[a-zA-Z\\-]+)|[a-яА
 export const regexPassword: RegExp = /^[A-Za-z\d!@#$%^&*()-_+=<>?]{4,256}$/;
 export const regexPhoneNumberKazakhstan: RegExp = /^\+7 \(\d{3}\) \d{3}-\d{2}-\d{2}$/;
 //export const API_URL = 'http://127.0.0.1:8000';
-export const API_URL = 'http://45.82.14.98:8000';
+export const API_URL = 'https://45.82.14.98:8000';

--- a/src/utils/consts.tsx
+++ b/src/utils/consts.tsx
@@ -6,4 +6,4 @@ export const regexClientName: RegExp = /^([a-zA-Z\\-]+(?:\s[a-zA-Z\\-]+)|[a-яА
 export const regexPassword: RegExp = /^[A-Za-z\d!@#$%^&*()-_+=<>?]{4,256}$/;
 export const regexPhoneNumberKazakhstan: RegExp = /^\+7 \(\d{3}\) \d{3}-\d{2}-\d{2}$/;
 //export const API_URL = 'http://127.0.0.1:8000';
-export const API_URL = 'https://45.82.14.98:8000';
+export const API_URL = 'https://45.82.14.98';

--- a/src/utils/consts.tsx
+++ b/src/utils/consts.tsx
@@ -6,4 +6,4 @@ export const regexClientName: RegExp = /^([a-zA-Z\\-]+(?:\s[a-zA-Z\\-]+)|[a-яА
 export const regexPassword: RegExp = /^[A-Za-z\d!@#$%^&*()-_+=<>?]{4,256}$/;
 export const regexPhoneNumberKazakhstan: RegExp = /^\+7 \(\d{3}\) \d{3}-\d{2}-\d{2}$/;
 //export const API_URL = 'http://127.0.0.1:8000';
-export const API_URL = 'https://45.82.14.98';
+export const API_URL = 'http://bronfood.sytes.net';

--- a/src/utils/consts.tsx
+++ b/src/utils/consts.tsx
@@ -6,4 +6,4 @@ export const regexClientName: RegExp = /^([a-zA-Z\\-]+(?:\s[a-zA-Z\\-]+)|[a-яА
 export const regexPassword: RegExp = /^[A-Za-z\d!@#$%^&*()-_+=<>?]{4,256}$/;
 export const regexPhoneNumberKazakhstan: RegExp = /^\+7 \(\d{3}\) \d{3}-\d{2}-\d{2}$/;
 //export const API_URL = 'http://127.0.0.1:8000';
-export const API_URL = 'http://45.82.14.98';
+export const API_URL = 'https://45.82.14.98';

--- a/src/utils/consts.tsx
+++ b/src/utils/consts.tsx
@@ -6,4 +6,4 @@ export const regexClientName: RegExp = /^([a-zA-Z\\-]+(?:\s[a-zA-Z\\-]+)|[a-яА
 export const regexPassword: RegExp = /^[A-Za-z\d!@#$%^&*()-_+=<>?]{4,256}$/;
 export const regexPhoneNumberKazakhstan: RegExp = /^\+7 \(\d{3}\) \d{3}-\d{2}-\d{2}$/;
 //export const API_URL = 'http://127.0.0.1:8000';
-export const API_URL = 'https://45.82.14.98';
+export const API_URL = 'http://45.82.14.98';


### PR DESCRIPTION
ПР для этих тикетов https://github.com/orgs/bronfood-com/projects/1/views/1?pane=issue&itemId=45317274 
https://github.com/orgs/bronfood-com/projects/1/views/1?pane=issue&itemId=59902178

1. Заюзан authServiceReal вместо мокового.
2. Запросы теперь отправляются на https://bronfood.sytes.net из локалхоста и gh-pages
3. В authServiceReal добавлена проверка, что если результат fetch не ОК, то сервис выкидывает ошибку. Об этом прочитал здесь https://tanstack.com/query/latest/docs/framework/react/guides/query-functions#usage-with-fetch-and-other-clients-that-do-not-throw-by-default
4. Добавлен метод reset() для мутаций, чтобы при закрытии попапов инвалидировались errors и data в мутациях. О reset() можно почитать здесь https://tanstack.com/query/latest/docs/framework/react/guides/mutations#resetting-mutation-state
5. В случае ошибки сервера при логауте определил такое поведение, что юзер разлогинивается в любом случае, но тогда его сессия останется активной на сервере. Нет ли здесь секьюрити-рисков?